### PR TITLE
Remove mima binary checks to itkit

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -70,20 +70,3 @@ jobs:
           key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}-${{ hashFiles('**/plugins.sbt') }}-${{ hashFiles('**/build.properties') }}
       - name: Run scapegoat
         run: sbt scapegoat
-
-  mima:
-    name: Report Binary Issues
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache SBT & ivy cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.ivy2
-            ~/.sbt
-            ~/.m2
-            ~/.cache/coursier/
-          key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}-${{ hashFiles('**/plugins.sbt') }}-${{ hashFiles('**/build.properties') }}
-      - name: Run mima
-        run: sbt mimaReportBinaryIssues

--- a/build.sbt
+++ b/build.sbt
@@ -93,8 +93,7 @@ lazy val commonSettings =
     sbtSettings ++
     scalaFmtSettings ++
     scapegoatSettings ++
-    sbtGitSettings ++
-    mimaSettings
+    sbtGitSettings
 
 lazy val compilerSettings =
   Seq(
@@ -172,6 +171,3 @@ lazy val sbtGitSettings = Seq(
   }
 )
 
-lazy val mimaSettings = Seq(
-  mimaPreviousArtifacts := Set("io.moia" %% "itkit" % "2.0.0")
-)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,5 +24,3 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.18")
 // publishSigned
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
-// sbt> mimaReportBinaryIssues
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.2")


### PR DESCRIPTION
With Akka being replaced with Pekko the mima checks will always fail as the binary will no longer be compatible with itkit