### PR TITLE
Fix actions that require sbt

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -16,6 +16,7 @@ jobs:
             ~/.m2
             ~/.cache/coursier/
           key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}-${{ hashFiles('**/plugins.sbt') }}-${{ hashFiles('**/build.properties') }}
+      - uses: sbt/setup-sbt@v1
       - name: Scalafmt
         run: sbt scalafmtCheckAll
 
@@ -33,6 +34,7 @@ jobs:
             ~/.m2
             ~/.cache/coursier/
           key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}-${{ hashFiles('**/plugins.sbt') }}-${{ hashFiles('**/build.properties') }}
+      - uses: sbt/setup-sbt@v1
       - name: Compile
         run: sbt +compile
 
@@ -51,6 +53,7 @@ jobs:
             ~/.m2
             ~/.cache/coursier/
           key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}-${{ hashFiles('**/plugins.sbt') }}-${{ hashFiles('**/build.properties') }}
+      - uses: sbt/setup-sbt@v1
       - name: Test Samples
         run: sbt +samples/it:test
 
@@ -68,5 +71,6 @@ jobs:
             ~/.m2
             ~/.cache/coursier/
           key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}-${{ hashFiles('**/plugins.sbt') }}-${{ hashFiles('**/build.properties') }}
+      - uses: sbt/setup-sbt@v1
       - name: Run scapegoat
         run: sbt scapegoat

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           app_id: 162267
           private_key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}
-
+      - uses: sbt/setup-sbt@v1
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
         with:


### PR DESCRIPTION
Because sbt is no longer bundled in the Github Ubuntu runner, we need to "import it" explicitly in the actions.

All the dependency updates and releases are blocked until we merge this.